### PR TITLE
fix: remove `version` deprecation

### DIFF
--- a/files/.github/workflows/ci.yml
+++ b/files/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        version: ${{ matrix.node }}
+        node-version: ${{ matrix.node }}
 
     - run: npm ci
     - run: npm test

--- a/test/fixtures/default/ci.yml
+++ b/test/fixtures/default/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        version: ${{ matrix.node }}
+        node-version: ${{ matrix.node }}
 
     - run: npm ci
     - run: npm test


### PR DESCRIPTION
Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead